### PR TITLE
Multi service

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,7 @@ To experiment with it you need a working tempest installation and
 configuration. I used devstack with::
 
     enable_service tempest
+    INSTALL_TEMPEST=True
 
 in local.conf.
 
@@ -24,14 +25,18 @@ cd into it and do the equivalent of::
 If you are using virtualenvs or need sudo, your form will be
 different.
 
-Go to the tempest directory and run testr limit the test run to
-gabbi related tests::
+Go to the tempest directory (often ``/opt/stack/tempest``) and run
+tempest limiting the test run to gabbi related tests::
 
-    testr run gabbi --subunit |subunit-trace
+    tempest run --regex gabbi
+
+You can be more specific if you like::
+
+    tempest run --regex PlacementNovaGabbi
 
 This will run the tests described by the YAML files in
 ``gabbi_tempest/tests/scenario/gabbits/``. Edit those files and run
-the testr command again for fun and adventure.
+the tempest command again for fun and adventure.
 
 .. _gnocchi: https://review.openstack.org/#/c/301585/
 .. _gabbi: https://gabbi.readthedocs.org/

--- a/gabbi_tempest/tests/scenario/__init__.py
+++ b/gabbi_tempest/tests/scenario/__init__.py
@@ -49,6 +49,8 @@ class GenericGabbiTest(tempest.test.BaseTestCase):
             name = '%s_BASE' % service_type.upper()
             os.environ[name] = '://'.join(urlparse.urlparse(url)[0:2])
         os.environ['SERVICE_TOKEN'] = token
+        os.environ['IMAGE_REF'] = CONF.compute.image_ref
+        os.environ['FLAVOR_REF'] = CONF.compute.flavor_ref
 
         if cls.service_type in endpoints:
             host = None
@@ -105,17 +107,8 @@ class GenericGabbiTest(tempest.test.BaseTestCase):
 
 class NovaGabbiTest(GenericGabbiTest):
     credentials = ['admin']
-    # NOTE(cdent): WTF? 'nova' being the thing in service_available?
-    # Boo!
     service_name = 'nova'
     service_type = 'compute'
-
-    @classmethod
-    def resource_setup(cls):
-        super(NovaGabbiTest, cls).resource_setup()
-        # TODO(cdent): not very generic!
-        os.environ['IMAGE_REF'] = CONF.compute.image_ref
-        os.environ['FLAVOR_REF'] = CONF.compute.flavor_ref
 
 
 class GlanceGabbiTest(GenericGabbiTest):

--- a/gabbi_tempest/tests/scenario/__init__.py
+++ b/gabbi_tempest/tests/scenario/__init__.py
@@ -46,6 +46,8 @@ class GenericGabbiTest(tempest.test.BaseTestCase):
         for service_type, url in endpoints.items():
             name = '%s_SERVICE' % service_type.upper()
             os.environ[name] = url
+            name = '%s_BASE' % service_type.upper()
+            os.environ[name] = '://'.join(urlparse.urlparse(url)[0:2])
         os.environ['SERVICE_TOKEN'] = token
 
         if cls.service_type in endpoints:
@@ -120,3 +122,9 @@ class GlanceGabbiTest(GenericGabbiTest):
     credentials = ['admin']
     service_name = 'glance'
     service_type = 'image'
+
+
+class PlacementNovaGabbiTest(GenericGabbiTest):
+    credentials = ['admin']
+    service_name = 'nova'
+    service_type = 'multi'

--- a/gabbi_tempest/tests/scenario/__init__.py
+++ b/gabbi_tempest/tests/scenario/__init__.py
@@ -46,10 +46,17 @@ class GenericGabbiTest(tempest.test.BaseTestCase):
             name = '%s_SERVICE' % service_type.upper()
             os.environ[name] = url
 
+        if cls.service_type in endpoints:
+            host = None
+            url = endpoints[cls.service_type]
+        else:
+            host = 'stub'
+            url = None
+
         test_dir = os.path.join(os.path.dirname(__file__), 'gabbits',
                                 cls.service_type)
         cls.tests = driver.build_tests(
-            test_dir, unittest.TestLoader(), host='stub',
+            test_dir, unittest.TestLoader(), host=host, url=url,
             test_loader_name='tempest.scenario.%s.%s' % (
                 cls.__name__, cls.service_type))
 

--- a/gabbi_tempest/tests/scenario/__init__.py
+++ b/gabbi_tempest/tests/scenario/__init__.py
@@ -51,6 +51,7 @@ class GenericGabbiTest(tempest.test.BaseTestCase):
         os.environ['SERVICE_TOKEN'] = token
         os.environ['IMAGE_REF'] = CONF.compute.image_ref
         os.environ['FLAVOR_REF'] = CONF.compute.flavor_ref
+        os.environ['FLAVOR_REF_ALT'] = CONF.compute.flavor_ref_alt
 
         if cls.service_type in endpoints:
             host = None

--- a/gabbi_tempest/tests/scenario/gabbits/compute/base.yaml
+++ b/gabbi_tempest/tests/scenario/gabbits/compute/base.yaml
@@ -9,21 +9,21 @@ defaults:
 tests:
 
 - name: retrieve root
-  GET: $ENVIRON['COMPUTE_SERVICE']/
+  GET: /
   response_json_paths:
       # $NETLOC contains the /v2.1 prefix
       $.version.links[?rel = "self"].href: /$ENVIRON['COMPUTE_SERVICE']/
       $.version.status: CURRENT
 
 - name: retrieve empty servers
-  GET: $ENVIRON['COMPUTE_SERVICE']/servers
+  GET: /servers
   response_json_paths:
       $.servers: []
 
 - name: try bad accept
   desc: https://bugs.launchpad.net/nova/+bug/1567966
   xfail: True
-  GET: $ENVIRON['COMPUTE_SERVICE']/servers
+  GET: /servers
   request_headers:
       accept: text/plain
   status: 406
@@ -31,20 +31,20 @@ tests:
 - name: try bad method
   desc: https://bugs.launchpad.net/nova/+bug/1567970
   xfail: True
-  DELETE: $ENVIRON['COMPUTE_SERVICE']/servers
+  DELETE: /servers
   status: 405
 
 - name: post bad content-type
   desc: https://bugs.launchpad.net/nova/+bug/1567977
   xfail: True
-  POST: $ENVIRON['COMPUTE_SERVICE']/servers
+  POST: /servers
   request_headers:
       content-type: text/plain
   data: I want a server so badly
   status: 415
 
 - name: create server
-  POST: $ENVIRON['COMPUTE_SERVICE']/servers
+  POST: /servers
   request_headers:
       content-type: application/json
   data:
@@ -68,7 +68,7 @@ tests:
 
 # bookmark link, whatever it is, is busted. Goes to bad version
 # - name: get bookmark
-#   GET: $ENVIRON['COMPUTE_SERVICE']/$RESPONSE['$.server.links[?rel = "bookmark"].href']
+#   GET: $RESPONSE['$.server.links[?rel = "bookmark"].href']
 
 - name: get server
   GET: $RESPONSE['$.server.links[?rel = "self"].href']

--- a/gabbi_tempest/tests/scenario/gabbits/compute/base.yaml
+++ b/gabbi_tempest/tests/scenario/gabbits/compute/base.yaml
@@ -9,21 +9,21 @@ defaults:
 tests:
 
 - name: retrieve root
-  GET: /
+  GET: $ENVIRON['COMPUTE_SERVICE']/
   response_json_paths:
       # $NETLOC contains the /v2.1 prefix
-      $.version.links[?rel = "self"].href: $SCHEME://$NETLOC/
+      $.version.links[?rel = "self"].href: /$ENVIRON['COMPUTE_SERVICE']/
       $.version.status: CURRENT
 
 - name: retrieve empty servers
-  GET: /servers
+  GET: $ENVIRON['COMPUTE_SERVICE']/servers
   response_json_paths:
       $.servers: []
 
 - name: try bad accept
   desc: https://bugs.launchpad.net/nova/+bug/1567966
   xfail: True
-  GET: /servers
+  GET: $ENVIRON['COMPUTE_SERVICE']/servers
   request_headers:
       accept: text/plain
   status: 406
@@ -31,20 +31,20 @@ tests:
 - name: try bad method
   desc: https://bugs.launchpad.net/nova/+bug/1567970
   xfail: True
-  DELETE: /servers
+  DELETE: $ENVIRON['COMPUTE_SERVICE']/servers
   status: 405
 
 - name: post bad content-type
   desc: https://bugs.launchpad.net/nova/+bug/1567977
   xfail: True
-  POST: /servers
+  POST: $ENVIRON['COMPUTE_SERVICE']/servers
   request_headers:
       content-type: text/plain
   data: I want a server so badly
   status: 415
 
 - name: create server
-  POST: /servers
+  POST: $ENVIRON['COMPUTE_SERVICE']/servers
   request_headers:
       content-type: application/json
   data:
@@ -66,11 +66,11 @@ tests:
   response_json_paths:
       $.server.status: ACTIVE
 
-- name: get bookmark
-  GET: $RESPONSE['$.server.links[?rel = "bookmark"].href']
-  status: 300
+# bookmark link, whatever it is, is busted. Goes to bad version
+# - name: get bookmark
+#   GET: $ENVIRON['COMPUTE_SERVICE']/$RESPONSE['$.server.links[?rel = "bookmark"].href']
 
-- name: get 2.1 server via bookmark
-  GET: $RESPONSE['$.choices[?status = "CURRENT"].links[?rel = "self"].href']
+- name: get server
+  GET: $RESPONSE['$.server.links[?rel = "self"].href']
   response_json_paths:
       $.server.name: new-server-one

--- a/gabbi_tempest/tests/scenario/gabbits/image/base.yaml
+++ b/gabbi_tempest/tests/scenario/gabbits/image/base.yaml
@@ -9,7 +9,7 @@ defaults:
 tests:
 
 - name: retrieve root
-  GET: /
+  GET: $ENVIRON['IMAGE_SERVICE']/
   status: 300
 
 - name: choose current api
@@ -18,16 +18,16 @@ tests:
   GET: $RESPONSE['$.versions[?status = "CURRENT"].links[?rel = "self"].href']
 
 - name: get images
-  GET: /v2/images
+  GET: $ENVIRON['IMAGE_SERVICE']/v2/images
   
 - name: get one image
-  GET: $RESPONSE['$.images[0].self']
+  GET: $ENVIRON['IMAGE_SERVICE']$RESPONSE['$.images[0].self']
   response_json_paths:
       $.status: active
       $.schema: /v2/schemas/image
 
 - name: get the schema
-  GET: $RESPONSE['$.schema']
+  GET: $ENVIRON['IMAGE_SERVICE']$RESPONSE['$.schema']
   response_json_paths:
       $.name: image
 

--- a/gabbi_tempest/tests/scenario/gabbits/image/base.yaml
+++ b/gabbi_tempest/tests/scenario/gabbits/image/base.yaml
@@ -9,7 +9,7 @@ defaults:
 tests:
 
 - name: retrieve root
-  GET: $ENVIRON['IMAGE_SERVICE']/
+  GET: /
   status: 300
 
 - name: choose current api
@@ -18,16 +18,16 @@ tests:
   GET: $RESPONSE['$.versions[?status = "CURRENT"].links[?rel = "self"].href']
 
 - name: get images
-  GET: $ENVIRON['IMAGE_SERVICE']/v2/images
+  GET: /v2/images
   
 - name: get one image
-  GET: $ENVIRON['IMAGE_SERVICE']$RESPONSE['$.images[0].self']
+  GET: $RESPONSE['$.images[0].self']
   response_json_paths:
       $.status: active
       $.schema: /v2/schemas/image
 
 - name: get the schema
-  GET: $ENVIRON['IMAGE_SERVICE']$RESPONSE['$.schema']
+  GET: $RESPONSE['$.schema']
   response_json_paths:
       $.name: image
 

--- a/gabbi_tempest/tests/scenario/gabbits/multi/base.yaml
+++ b/gabbi_tempest/tests/scenario/gabbits/multi/base.yaml
@@ -6,6 +6,19 @@ defaults:
         accept: application/json
         openstack-api-version: 'compute latest, placement latest'
 
+# These replace full nodes, there is no YAML interpolation
+# Experimenting with using YAML anchors to avoid repeating long expansions
+# within the tests.
+vars:
+    - &cn1_rp $ENVIRON['PLACEMENT_SERVICE']/resource_providers/$HISTORY['list hypervisors'].$RESPONSE['$.hypervisors[0].id']
+    - &cn1_inv $ENVIRON['PLACEMENT_SERVICE']/resource_providers/$HISTORY['list hypervisors'].$RESPONSE['$.hypervisors[0].id']/inventories
+    - &cn1_alloc $ENVIRON['PLACEMENT_SERVICE']/resource_providers/$HISTORY['list hypervisors'].$RESPONSE['$.hypervisors[0].id']/allocations
+    - &cn1_usages $ENVIRON['PLACEMENT_SERVICE']/resource_providers/$HISTORY['list hypervisors'].$RESPONSE['$.hypervisors[0].id']/usages
+
+    - &s1_id $HISTORY['get server'].$RESPONSE['$.server.id']
+    - &s1_url $ENVIRON['COMPUTE_SERVICE']/servers/$HISTORY['get server'].$RESPONSE['$.server.id']
+    - &s1_alloc $ENVIRON['PLACEMENT_SERVICE']/allocations/$HISTORY['get server'].$RESPONSE['$.server.id']
+
 tests:
 
     - name: list hypervisors
@@ -18,9 +31,50 @@ tests:
       response_json_paths:
           $.uuid: $RESPONSE['$.hypervisors[0].id']
 
-    - name: blargh inventory
-      verbose: True
-      GET: $ENVIRON['PLACEMENT_BASE']$RESPONSE['$.links[?rel=inventories].href']
+    - name: confirm inventory
+      GET: *cn1_inv
       response_json_paths:
           $.inventories.VCPU.allocation_ratio: 16
 
+    - &cn1_zero
+      name: confirm empty allocation
+      GET: *cn1_alloc
+      response_json_paths:
+          $.allocations.`len`: 0
+
+    - name: create server
+      POST: $ENVIRON['COMPUTE_SERVICE']/servers
+      data:
+          server:
+              name: new-server-one
+              networks: auto
+              imageRef: $ENVIRON['IMAGE_REF']
+              flavorRef: $ENVIRON['FLAVOR_REF']
+      status: 202
+
+    - name: get server
+      GET: $LOCATION
+
+    - name: watch allocations
+      verbose: True
+      GET: *s1_alloc
+      poll:
+          count: 4
+          delay: 1
+      response_json_paths:
+          $.allocations.["$HISTORY['list hypervisors'].$RESPONSE['$.hypervisors[0].id']"].resources:
+              VCPU: 1
+              MEMORY_MB: 64
+
+### Clean Up
+
+    - name: delete server
+      DELETE: *s1_url
+      status: 204
+
+    - name: reconfirm empty allocation
+      <<: *cn1_zero
+      verbose: True
+      poll:
+          count: 10
+          delay: 1

--- a/gabbi_tempest/tests/scenario/gabbits/multi/base.yaml
+++ b/gabbi_tempest/tests/scenario/gabbits/multi/base.yaml
@@ -15,8 +15,8 @@ vars:
     - &cn1_alloc $ENVIRON['PLACEMENT_SERVICE']/resource_providers/$HISTORY['list hypervisors'].$RESPONSE['$.hypervisors[0].id']/allocations
     - &cn1_usages $ENVIRON['PLACEMENT_SERVICE']/resource_providers/$HISTORY['list hypervisors'].$RESPONSE['$.hypervisors[0].id']/usages
 
-    - &s1_id $HISTORY['get server'].$RESPONSE['$.server.id']
     - &s1_url $ENVIRON['COMPUTE_SERVICE']/servers/$HISTORY['get server'].$RESPONSE['$.server.id']
+    - &s1_action $ENVIRON['COMPUTE_SERVICE']/servers/$HISTORY['get server'].$RESPONSE['$.server.id']/action
     - &s1_alloc $ENVIRON['PLACEMENT_SERVICE']/allocations/$HISTORY['get server'].$RESPONSE['$.server.id']
 
 tests:
@@ -27,7 +27,7 @@ tests:
           $.hypervisors.`len`: 1
 
     - name: confirm resource provider
-      GET: $ENVIRON['PLACEMENT_SERVICE']/resource_providers/$RESPONSE['$.hypervisors[0].id']
+      GET: *cn1_rp
       response_json_paths:
           $.uuid: $RESPONSE['$.hypervisors[0].id']
 
@@ -56,7 +56,6 @@ tests:
       GET: $LOCATION
 
     - name: watch allocations
-      verbose: True
       GET: *s1_alloc
       poll:
           count: 4
@@ -66,6 +65,84 @@ tests:
               VCPU: 1
               MEMORY_MB: 64
 
+    - name: server active
+      GET: *s1_url
+      poll:
+          count: 10
+          delay: .5
+      response_json_paths:
+          $.server.status: ACTIVE
+
+    - name: resize server
+      POST: *s1_action
+      data:
+          resize:
+             flavorRef: $ENVIRON['FLAVOR_REF_ALT']
+             OS-DCF:diskConfig: AUTO
+      status: 202
+
+    - name: wait for verify resize
+      GET: *s1_url
+      poll:
+          count: 12
+          delay: 5
+      response_json_paths:
+          $.server.status: VERIFY_RESIZE
+
+# These next two fail. We are not managing allocations for local
+# resize (yet).
+    - name: check for double allocations
+      verbose: True
+      GET: *s1_alloc
+      poll:
+          count: 10
+          delay: 1
+      response_json_paths:
+          $.allocations.["$HISTORY['list hypervisors'].$RESPONSE['$.hypervisors[0].id']"].resources:
+              VCPU: 2
+              MEMORY_MB: 192
+
+    - name: confirm usages pending
+      verbose: True
+      GET: *cn1_usages
+      response_json_paths:
+          $.usages:
+              DISK_GB: 0
+              MEMORY_MB: 192
+              VCPU: 2
+
+    - name: confirm resize
+      POST: *s1_action
+      data:
+          confirmResize: null
+      status: 204
+
+    - name: wait for active
+      GET: *s1_url
+      poll:
+          count: 12
+          delay: 5
+      response_json_paths:
+          $.server.status: ACTIVE
+
+    - name: changed to correct allocations
+      GET: *s1_alloc
+      poll:
+          count: 12
+          delay: 5
+      response_json_paths:
+          $.allocations.["$HISTORY['list hypervisors'].$RESPONSE['$.hypervisors[0].id']"].resources:
+              VCPU: 1
+              MEMORY_MB: 128
+
+    - name: confirm usages active
+      GET: *cn1_usages
+      response_json_paths:
+          $.usages:
+              DISK_GB: 0
+              MEMORY_MB: 128
+              VCPU: 1
+
 ### Clean Up
 
     - name: delete server
@@ -74,7 +151,6 @@ tests:
 
     - name: reconfirm empty allocation
       <<: *cn1_zero
-      verbose: True
       poll:
           count: 10
           delay: 1

--- a/gabbi_tempest/tests/scenario/gabbits/multi/base.yaml
+++ b/gabbi_tempest/tests/scenario/gabbits/multi/base.yaml
@@ -1,0 +1,26 @@
+
+defaults:
+    request_headers:
+        x-auth-token: $ENVIRON['SERVICE_TOKEN']
+        content-type: application/json
+        accept: application/json
+        openstack-api-version: 'compute latest, placement latest'
+
+tests:
+
+    - name: list hypervisors
+      GET: $ENVIRON['COMPUTE_SERVICE']/os-hypervisors
+      response_json_paths:
+          $.hypervisors.`len`: 1
+
+    - name: confirm resource provider
+      GET: $ENVIRON['PLACEMENT_SERVICE']/resource_providers/$RESPONSE['$.hypervisors[0].id']
+      response_json_paths:
+          $.uuid: $RESPONSE['$.hypervisors[0].id']
+
+    - name: blargh inventory
+      verbose: True
+      GET: $ENVIRON['PLACEMENT_BASE']$RESPONSE['$.links[?rel=inventories].href']
+      response_json_paths:
+          $.inventories.VCPU.allocation_ratio: 16
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,4 +30,4 @@ source-dir = docs/source
 
 [entry_points]
 tempest.test_plugins =
-    plugin_name = gabbi_tempest.plugin:GabbiTempestPlugin
+    gabbi = gabbi_tempest.plugin:GabbiTempestPlugin


### PR DESCRIPTION
Switch over to allowing multiple services in the yaml file by requiring hosts in the request URLs.

Each service in the catalog gets a `<TYPE>_SERVICE` and `<TYPE>_BASE` `$ENVIRON` that points to the service endpoint and base http://host of the service.